### PR TITLE
:bookmark: 使版本号格式符合 APK 要求

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Set variables
         run: |
-          echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
-          echo "RELEASE_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+          echo "TAG_NAME=$(date +%Y.%m.%d.%H%M)" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
           echo "YEAR=$(date +%Y)" >> $GITHUB_ENV
           echo "MONTH=$(date +%m)" >> $GITHUB_ENV
         shell: bash


### PR DESCRIPTION
解决 [immortalwrt/issue#1641](https://github.com/immortalwrt/packages/issues/1641) 和 [small/issue#192](https://github.com/kenzok8/small/issues/192).

简而言之就是, OpenWrt 转向 APK 包管理器而弃用 OPKG, APK 要求软件包版本号符合特定格式, 而这个仓库的软件包版本不符合, 因而会在编译构建时报错. 这个 PR 仅更改软件发布版本号为符合 APK 要求的格式.