### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
       - "LICENSE"
       - "**/dependabot.yml"
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
Potential fix for [https://github.com/v2fly/geoip/security/code-scanning/1](https://github.com/v2fly/geoip/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (best here since there is one job) to document and enforce least privilege.

For this specific workflow:
- `contents: write` is required because it pushes commits/branch updates and creates a GitHub release (release operations are under repository contents scope for `GITHUB_TOKEN`).
- No other scopes are needed based on shown steps.

Edit **`.github/workflows/build.yml`** by inserting `permissions:` after the trigger section (`on:` block) and before `concurrency:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
